### PR TITLE
Add script to generate PDFs from real Shippo orders

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,4 @@ build/
 # Generated PDFs
 test-packing-slip.pdf
 packing-slip-*.pdf
+output/

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "dev": "tsc --watch",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
+    "generate": "yarn build && node dist/generate-real-pdfs.js",
     "lint": "eslint . --ext .ts,.tsx",
     "lint:fix": "eslint . --ext .ts,.tsx --fix",
     "sort-package": "yarn dlx sort-package-json",

--- a/src/generate-real-pdfs.ts
+++ b/src/generate-real-pdfs.ts
@@ -1,0 +1,114 @@
+import dotenv from 'dotenv';
+import path from 'path';
+
+import { generatePackingSlip } from './lib/pdf-generator';
+import { fetchOrders } from './lib/shippo';
+
+// Load environment variables
+dotenv.config({ path: '.env.local' });
+
+/**
+ * Generate packing slip PDFs for real orders from Shippo
+ * Fetches orders from the last 24 hours and generates a PDF for each
+ */
+async function generateRealPDFs() {
+  console.log('Generating packing slips from real Shippo orders...\n');
+
+  // Verify API token is configured
+  const apiToken = process.env.SHIPPO_API_TOKEN;
+  if (!apiToken) {
+    console.error('Error: SHIPPO_API_TOKEN not found in .env.local');
+    console.error('Please add your production API token');
+    process.exit(2);
+  }
+
+  // Calculate date range (last 24 hours by default)
+  const endDate = new Date();
+  const startDate = new Date();
+  const hoursBack = 24; // Can be adjusted as needed
+  startDate.setHours(startDate.getHours() - hoursBack);
+
+  console.log('Fetching orders from:');
+  console.log('  Start:', startDate.toISOString());
+  console.log('  End:', endDate.toISOString());
+  console.log('');
+
+  try {
+    // Fetch orders from Shippo
+    const orders = await fetchOrders(startDate, endDate);
+
+    if (orders.length === 0) {
+      console.log('No orders found in the specified date range.');
+      console.log('Try adjusting the time window or check your Shippo account.');
+      process.exit(0);
+    }
+
+    console.log(`✓ Found ${orders.length} order(s)\n`);
+
+    // Create output directory if it doesn't exist
+    const outputDir = path.join(process.cwd(), 'output');
+    const fs = await import('fs/promises');
+    await fs.mkdir(outputDir, { recursive: true });
+
+    // Generate PDF for each order
+    let successCount = 0;
+    let errorCount = 0;
+
+    for (const order of orders) {
+      const orderNumber = order.orderNumber || order.objectId || 'unknown';
+      const sanitizedOrderNumber = orderNumber.replace(/[^a-zA-Z0-9-_]/g, '_');
+      const outputPath = path.join(
+        outputDir,
+        `packing-slip-${sanitizedOrderNumber}.pdf`,
+      );
+
+      try {
+        await generatePackingSlip(order, outputPath);
+        console.log(`✓ Generated: ${path.basename(outputPath)}`);
+        console.log(`  Order: ${orderNumber}`);
+        console.log(`  Items: ${order.lineItems?.length || 0}`);
+        console.log(`  Ship to: ${order.toAddress?.name || 'N/A'}`);
+        console.log('');
+        successCount++;
+      } catch (error) {
+        console.error(`✗ Failed to generate PDF for order ${orderNumber}`);
+        if (error instanceof Error) {
+          console.error(`  Error: ${error.message}`);
+        }
+        console.log('');
+        errorCount++;
+      }
+    }
+
+    // Summary
+    console.log('='.repeat(50));
+    console.log('Summary:');
+    console.log(`  Total orders: ${orders.length}`);
+    console.log(`  Successfully generated: ${successCount}`);
+    console.log(`  Errors: ${errorCount}`);
+    console.log(`  Output directory: ${outputDir}`);
+    console.log('='.repeat(50));
+
+    if (successCount > 0) {
+      console.log('\nTo view PDFs:');
+      console.log(`  open ${outputDir}`);
+    }
+
+    process.exit(errorCount > 0 ? 1 : 0);
+  } catch (error) {
+    console.error('✗ Failed to generate packing slips\n');
+    if (error instanceof Error) {
+      console.error('Error:', error.message);
+      if (error.stack) {
+        console.error('\nStack trace:');
+        console.error(error.stack);
+      }
+    } else {
+      console.error('Error:', error);
+    }
+    process.exit(1);
+  }
+}
+
+// Run the script
+void generateRealPDFs();

--- a/src/lib/pdf-generator.ts
+++ b/src/lib/pdf-generator.ts
@@ -232,7 +232,7 @@ function renderHeader(
   });
   doc
     .font('Inter')
-    .text(order.objectId || 'N/A', valueColumnStart, orderDetailsY);
+    .text(order.orderNumber || order.objectId || 'N/A', valueColumnStart, orderDetailsY);
   orderDetailsY += LINE_HEIGHT;
 
   // Order Date with right-aligned label and left-aligned value
@@ -248,7 +248,8 @@ function renderHeader(
   }
 
   // Total Items with right-aligned label and left-aligned value
-  const totalItems = order.lineItems?.length || 0;
+  const totalItems =
+    order.lineItems?.reduce((sum, item) => sum + (item.quantity || 0), 0) || 0;
   doc.font('Inter-Bold').text('Total Items:', midPoint, orderDetailsY, {
     align: 'right',
     width: maxLabelWidth,
@@ -376,11 +377,12 @@ function renderItemsTable(
 
     // Variant title (if present)
     if (item.variantTitle) {
-      doc.text(item.variantTitle, itemsColumnX, y, {
+      doc.font('Inter-Bold').text(item.variantTitle, itemsColumnX, y, {
         ellipsis: true,
         height: singleLineHeight,
         width: itemsColumnWidth,
       });
+      doc.font('Inter'); // Reset to regular font
 
       y += singleLineHeight;
     }


### PR DESCRIPTION
## Summary
- Add `generate-real-pdfs.ts` script to fetch orders from Shippo API and generate packing slip PDFs
- Fix PDF generator to display order number instead of internal Shippo object ID
- Fix total items calculation to sum item quantities instead of counting line items
- Make variant titles bold for better visual distinction
- Add `output/` directory to .gitignore to prevent committing customer data

## Usage
Run `yarn generate` to fetch orders from the last 24 hours and generate PDFs in the `output/` directory.

## Test plan
- [x] Run `yarn generate` and verify PDFs are created
- [x] Verify Order ID shows order number (e.g., `#1068`) not Shippo object ID
- [x] Verify Total Items correctly sums all item quantities
- [x] Verify variant titles appear in bold
- [x] Verify `output/` directory is ignored by git