### PR TITLE
Add script to generate PDFs from real Shippo orders

### DIFF
--- a/src/generate-real-pdfs.ts
+++ b/src/generate-real-pdfs.ts
@@ -1,8 +1,12 @@
+import { exec } from 'child_process';
 import dotenv from 'dotenv';
 import path from 'path';
+import { promisify } from 'util';
 
 import { generatePackingSlip } from './lib/pdf-generator';
 import { fetchOrders } from './lib/shippo';
+
+const execAsync = promisify(exec);
 
 // Load environment variables
 dotenv.config({ path: '.env.local' });
@@ -68,6 +72,15 @@ async function generateRealPDFs() {
         console.log(`  Order: ${orderNumber}`);
         console.log(`  Items: ${order.lineItems?.length || 0}`);
         console.log(`  Ship to: ${order.toAddress?.name || 'N/A'}`);
+
+        // Open the PDF file
+        try {
+          await execAsync(`open "${outputPath}"`);
+          console.log(`  Opened PDF`);
+        } catch (openError) {
+          console.log(`  (Could not auto-open PDF)`);
+        }
+
         console.log('');
         successCount++;
       } catch (error) {
@@ -88,11 +101,6 @@ async function generateRealPDFs() {
     console.log(`  Errors: ${errorCount}`);
     console.log(`  Output directory: ${outputDir}`);
     console.log('='.repeat(50));
-
-    if (successCount > 0) {
-      console.log('\nTo view PDFs:');
-      console.log(`  open ${outputDir}`);
-    }
 
     process.exit(errorCount > 0 ? 1 : 0);
   } catch (error) {


### PR DESCRIPTION
## Summary
- Add `generate-real-pdfs.ts` script to fetch orders from Shippo API and generate packing slip PDFs
- Fix PDF generator to display order number instead of internal Shippo object ID
- Fix total items calculation to sum item quantities instead of counting line items
- Make variant titles bold for better visual distinction
- Add `output/` directory to .gitignore to prevent committing customer data
- Auto-open each generated PDF for quick review

## Usage
Run `yarn generate` to fetch orders from the last 24 hours and generate PDFs in the `output/` directory.

Each PDF will automatically open in your default PDF viewer as it's created.

## Test plan
- [x] Run `yarn generate` and verify PDFs are created
- [x] Verify Order ID shows order number (e.g., `#1068`) not Shippo object ID
- [x] Verify Total Items correctly sums all item quantities
- [x] Verify variant titles appear in bold
- [x] Verify `output/` directory is ignored by git
- [x] Verify PDFs auto-open after generation