### PR TITLE
Dry up PDF generation code

### DIFF
--- a/src/generate-real-pdfs.ts
+++ b/src/generate-real-pdfs.ts
@@ -43,7 +43,9 @@ async function generateRealPDFs() {
 
     if (orders.length === 0) {
       console.log('No orders found in the specified date range.');
-      console.log('Try adjusting the time window or check your Shippo account.');
+      console.log(
+        'Try adjusting the time window or check your Shippo account.',
+      );
       process.exit(0);
     }
 
@@ -77,7 +79,7 @@ async function generateRealPDFs() {
         try {
           await execAsync(`open "${outputPath}"`);
           console.log(`  Opened PDF`);
-        } catch (openError) {
+        } catch {
           console.log(`  (Could not auto-open PDF)`);
         }
 


### PR DESCRIPTION
## Summary

Refactored PDF generation code to eliminate magic numbers and code duplication, making it more maintainable.

**Changes:**
- Extracted 10 magic numbers to well-named constants (typography, layout, table styling)
- Eliminated duplicate table header rendering code (extracted to `renderTableHeaders()` function)
- Simplified page break logic (extracted `calculateItemHeight()` helper)

**Fixes:** #20

## Test plan

- [x] `yarn lint` - No errors
- [x] `yarn format:check` - All files formatted correctly
- [x] `yarn typecheck` - No TypeScript errors
- [x] `yarn test:pdf` - Basic PDF generation passing
- [x] `yarn generate` - Real order PDF generation passing (2 orders tested)
- [x] Visual verification: Generated PDFs match previous output

## Technical details

**Before:**
- Magic numbers scattered throughout code (6, 4, 10, 30, 0.25, 0.5, 2, etc.)
- Table header rendering duplicated in 2 places
- Item height calculation duplicated for current and next items

**After:**
- All values extracted to named constants at top of file
- Single `renderTableHeaders()` function used in both places
- Single `calculateItemHeight()` function used for all calculations

No functional changes - purely refactoring for maintainability.