### PR TITLE
Configure yarn to use exact versions

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,1 +1,2 @@
+defaultSemverRangePrefix: ''
 nodeLinker: node-modules

--- a/package.json
+++ b/package.json
@@ -31,21 +31,21 @@
   },
   "prettier": "@bjeco/prettier-config",
   "dependencies": {
-    "dotenv": "^17.2.3",
-    "pdfkit": "^0.17.2",
-    "shippo": "^2.17.4"
+    "dotenv": "17.2.3",
+    "pdfkit": "0.17.2",
+    "shippo": "2.17.4"
   },
   "devDependencies": {
     "@bjeco/prettier-config": "*",
-    "@types/node": "^25.2.0",
-    "@types/pdfkit": "^0.17.4",
-    "@typescript-eslint/eslint-plugin": "^8.54.0",
-    "@typescript-eslint/parser": "^8.54.0",
-    "eslint": "^9.39.2",
-    "eslint-config-prettier": "^10.1.8",
-    "eslint-plugin-perfectionist": "^5.4.0",
-    "prettier": "^3.8.1",
-    "typescript": "^5.9.3"
+    "@types/node": "25.2.0",
+    "@types/pdfkit": "0.17.4",
+    "@typescript-eslint/eslint-plugin": "8.54.0",
+    "@typescript-eslint/parser": "8.54.0",
+    "eslint": "9.39.2",
+    "eslint-config-prettier": "10.1.8",
+    "eslint-plugin-perfectionist": "5.4.0",
+    "prettier": "3.8.1",
+    "typescript": "5.9.3"
   },
   "packageManager": "yarn@4.12.0"
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -156,7 +156,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/node@npm:*, @types/node@npm:^25.2.0":
+"@types/node@npm:*, @types/node@npm:25.2.0":
   version: 25.2.0
   resolution: "@types/node@npm:25.2.0"
   dependencies:
@@ -165,7 +165,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/pdfkit@npm:^0.17.4":
+"@types/pdfkit@npm:0.17.4":
   version: 0.17.4
   resolution: "@types/pdfkit@npm:0.17.4"
   dependencies:
@@ -174,7 +174,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@typescript-eslint/eslint-plugin@npm:^8.54.0":
+"@typescript-eslint/eslint-plugin@npm:8.54.0":
   version: 8.54.0
   resolution: "@typescript-eslint/eslint-plugin@npm:8.54.0"
   dependencies:
@@ -194,7 +194,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@typescript-eslint/parser@npm:^8.54.0":
+"@typescript-eslint/parser@npm:8.54.0":
   version: 8.54.0
   resolution: "@typescript-eslint/parser@npm:8.54.0"
   dependencies:
@@ -495,7 +495,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"dotenv@npm:^17.2.3":
+"dotenv@npm:17.2.3":
   version: 17.2.3
   resolution: "dotenv@npm:17.2.3"
   checksum: 10c0/c884403209f713214a1b64d4d1defa4934c2aa5b0002f5a670ae298a51e3c3ad3ba79dfee2f8df49f01ae74290fcd9acdb1ab1d09c7bfb42b539036108bb2ba0
@@ -509,7 +509,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eslint-config-prettier@npm:^10.1.8":
+"eslint-config-prettier@npm:10.1.8":
   version: 10.1.8
   resolution: "eslint-config-prettier@npm:10.1.8"
   peerDependencies:
@@ -520,7 +520,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eslint-plugin-perfectionist@npm:^5.4.0":
+"eslint-plugin-perfectionist@npm:5.4.0":
   version: 5.4.0
   resolution: "eslint-plugin-perfectionist@npm:5.4.0"
   dependencies:
@@ -556,7 +556,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eslint@npm:^9.39.2":
+"eslint@npm:9.39.2":
   version: 9.39.2
   resolution: "eslint@npm:9.39.2"
   dependencies:
@@ -996,7 +996,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"pdfkit@npm:^0.17.2":
+"pdfkit@npm:0.17.2":
   version: 0.17.2
   resolution: "pdfkit@npm:0.17.2"
   dependencies:
@@ -1039,7 +1039,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"prettier@npm:^3.8.1":
+"prettier@npm:3.8.1":
   version: 3.8.1
   resolution: "prettier@npm:3.8.1"
   bin:
@@ -1099,22 +1099,22 @@ __metadata:
   resolution: "shippo-packing-slips@workspace:."
   dependencies:
     "@bjeco/prettier-config": "npm:*"
-    "@types/node": "npm:^25.2.0"
-    "@types/pdfkit": "npm:^0.17.4"
-    "@typescript-eslint/eslint-plugin": "npm:^8.54.0"
-    "@typescript-eslint/parser": "npm:^8.54.0"
-    dotenv: "npm:^17.2.3"
-    eslint: "npm:^9.39.2"
-    eslint-config-prettier: "npm:^10.1.8"
-    eslint-plugin-perfectionist: "npm:^5.4.0"
-    pdfkit: "npm:^0.17.2"
-    prettier: "npm:^3.8.1"
-    shippo: "npm:^2.17.4"
-    typescript: "npm:^5.9.3"
+    "@types/node": "npm:25.2.0"
+    "@types/pdfkit": "npm:0.17.4"
+    "@typescript-eslint/eslint-plugin": "npm:8.54.0"
+    "@typescript-eslint/parser": "npm:8.54.0"
+    dotenv: "npm:17.2.3"
+    eslint: "npm:9.39.2"
+    eslint-config-prettier: "npm:10.1.8"
+    eslint-plugin-perfectionist: "npm:5.4.0"
+    pdfkit: "npm:0.17.2"
+    prettier: "npm:3.8.1"
+    shippo: "npm:2.17.4"
+    typescript: "npm:5.9.3"
   languageName: unknown
   linkType: soft
 
-"shippo@npm:^2.17.4":
+"shippo@npm:2.17.4":
   version: 2.17.4
   resolution: "shippo@npm:2.17.4"
   dependencies:
@@ -1181,7 +1181,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@npm:^5.9.3":
+"typescript@npm:5.9.3":
   version: 5.9.3
   resolution: "typescript@npm:5.9.3"
   bin:
@@ -1191,7 +1191,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@patch:typescript@npm%3A^5.9.3#optional!builtin<compat/typescript>":
+"typescript@patch:typescript@npm%3A5.9.3#optional!builtin<compat/typescript>":
   version: 5.9.3
   resolution: "typescript@patch:typescript@npm%3A5.9.3#optional!builtin<compat/typescript>::version=5.9.3&hash=5786d5"
   bin:


### PR DESCRIPTION
## Summary

Configured yarn to install exact package versions instead of using caret (^) version ranges.

**Changes:**
- Added `defaultSemverRangePrefix: ''` to `.yarnrc.yml`
- Removed caret (^) prefixes from all dependencies in `package.json`
- Kept `@bjeco/prettier-config` as `*` (workspace package)
- Updated `yarn.lock` to reflect exact versions

**Fixes:** #22

## Test plan

- [x] `yarn install` - Successfully reinstalled dependencies
- [x] `yarn lint` - No errors
- [x] `yarn typecheck` - No TypeScript errors
- [x] `yarn format:check` - All files formatted correctly
- [x] `yarn test:pdf` - PDF generation working correctly

## Benefits

- **Deterministic builds**: Same versions installed every time
- **Predictable updates**: Explicit version bumps required
- **Easier debugging**: No surprise version changes
- **Better CI/CD**: Consistent environments across all deployments

## Future behavior

When installing new packages with `yarn add`, they will be added with exact versions (e.g., `1.2.3` instead of `^1.2.3`).