### PR TITLE
Add Dependabot configuration for automated updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,38 @@
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: gitsubmodule
+    rebase-strategy: 'auto'
+    directory: '/'
+    schedule:
+      interval: 'daily'
+    open-pull-requests-limit: 1
+    commit-message:
+      prefix: 'chore'
+      prefix-development: 'chore'
+      include: 'scope'
+    labels:
+      - 'dependencies'
+
+  - package-ecosystem: npm
+    rebase-strategy: 'auto'
+    directory: '/'
+    schedule:
+      interval: 'daily'
+    open-pull-requests-limit: 1
+    versioning-strategy: increase
+    commit-message:
+      prefix: 'chore'
+      prefix-development: 'chore'
+      include: 'scope'
+    labels:
+      - 'dependencies'
+    groups:
+      development-dependencies:
+        dependency-type: 'development'
+    ignore:
+      - dependency-name: '*'
+        versions: ['version-update:semver-major']
+      - dependency-name: 'typescript' # This is likely to conflict with peer dependencies and stop the whole dependency update process
+        versions: ['*']


### PR DESCRIPTION
## Summary

Added comprehensive Dependabot configuration to automate dependency updates for both git submodules and npm packages.

**Changes:**
- ✅ Added `versioning-strategy: increase` to preserve exact versions (critical for #22)
- ✅ Fixed typo: "conflight" → "conflict"
- ✅ Added `open-pull-requests-limit: 1` to gitsubmodule config (consistency)
- ✅ Added conventional commit message formatting for both configs
- ✅ Added `dependencies` label to both configs
- ✅ Added development dependency grouping for npm

## Configuration Details

### Both Ecosystems (gitsubmodule & npm)
- **Schedule**: Daily checks
- **PR Limit**: Maximum 1 open PR at a time
- **Commit Messages**: Conventional commits with `chore` prefix and scope
- **Labels**: Auto-labeled as `dependencies`

### Git Submodules
- Auto rebase strategy for cleaner history

### NPM Packages
- **`versioning-strategy: increase`**: Maintains exact versions without semver prefixes (e.g., `1.2.3` not `^1.2.3`)
- **Groups**: Development dependencies grouped together
- **Ignores**: 
  - Major version updates (avoided for stability)
  - TypeScript updates (potential peer dependency conflicts)

## Why This Matters

This configuration ensures:
1. **Dependencies stay current** - Daily automated checks
2. **Exact version policy maintained** - `versioning-strategy: increase` preserves the exact version setup from #22
3. **Manageable updates** - Limited to 1 PR at a time, grouped logically
4. **Clear history** - Conventional commits with proper labeling
5. **Stability** - Major updates and problematic packages excluded

## Test Plan

Dependabot will automatically:
- Create PRs when updates are available
- Follow the exact version policy
- Use conventional commit format
- Apply the `dependencies` label

The configuration will be validated by GitHub when merged.