### PR TITLE
fix: load both .env and .env.local for environment variables

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,8 @@
 import dotenv from 'dotenv';
 
-// Load environment variables
-dotenv.config({ path: '.env.local' });
+// Load environment variables (.env.local overrides .env)
+dotenv.config();
+dotenv.config({ override: true, path: '.env.local' });
 
 // Verify environment setup
 const apiToken = process.env.SHIPPO_API_TOKEN;

--- a/src/test-shippo.ts
+++ b/src/test-shippo.ts
@@ -2,8 +2,9 @@ import dotenv from 'dotenv';
 
 import { fetchOrders } from './lib/shippo';
 
-// Load environment variables
-dotenv.config({ path: '.env.local' });
+// Load environment variables (.env.local overrides .env)
+dotenv.config();
+dotenv.config({ override: true, path: '.env.local' });
 
 /**
  * Test script to verify Shippo API connectivity


### PR DESCRIPTION
## Summary

- Replace hardcoded `.env.local` path in dotenv config with a two-pass load that supports both `.env` and `.env.local`
- `.env.local` values override `.env` when both are present
- Applies to `generate-real-pdfs.ts`, `index.ts`, and `test-shippo.ts`

## Motivation

The Pi deployment uses a `.env` file rather than `.env.local`. Hardcoding `.env.local` prevented the script from running on the Pi without workarounds.

## Test plan

- [ ] Verify script runs with `.env` only
- [ ] Verify script runs with `.env.local` only
- [ ] Verify `.env.local` values take precedence when both files exist