### PR TITLE
fix: add orderStatus parameter to fetchOrders

### DIFF
--- a/src/lib/shippo.ts
+++ b/src/lib/shippo.ts
@@ -1,4 +1,4 @@
-import type { Order } from 'shippo/models/components';
+import type { Order, OrderStatusEnum } from 'shippo/models/components';
 
 import { Shippo } from 'shippo';
 
@@ -24,11 +24,13 @@ export function createShippoClient(): Shippo {
  * Fetch orders from Shippo within a specified date range
  * @param startDate - Start of date range (orders placed after this time)
  * @param endDate - End of date range (orders placed before this time)
+ * @param orderStatus - Optional array of order statuses to filter by (e.g., [OrderStatusEnum.Paid])
  * @returns Array of order objects from Shippo
  */
 export async function fetchOrders(
   startDate: Date,
   endDate: Date,
+  orderStatus?: OrderStatusEnum[],
 ): Promise<Order[]> {
   const client = createShippoClient();
 
@@ -45,6 +47,7 @@ export async function fetchOrders(
       // Fetch orders for current page
       const response = await client.orders.list({
         endDate: endDateISO,
+        orderStatus,
         page,
         results: 25, // Default page size
         startDate: startDateISO,


### PR DESCRIPTION
## Summary

- Add optional `orderStatus` parameter to `fetchOrders` in `shippo.ts`
- Pass `orderStatus` through to the Shippo API `orders.list` call
- This unblocks `generate-real-pdfs.ts` which calls `fetchOrders` with a status filter

## Test plan

- [ ] `yarn build` completes without TypeScript errors
- [ ] `yarn generate` fetches orders filtered by `PAID` status