### PR TITLE
docs: linkify roadmap issues and add biome/lefthook/CI item

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,4 +61,4 @@ The script is deployed to a Raspberry Pi Zero 2 W. On every merge to `main`, Git
 curl -fsSL https://github.com/brianespinosa/shippo-packing-slips/releases/latest/download/bundle.js | node -
 ```
 
-See issue #26 for CD pipeline implementation status.
+See [issue #26](https://github.com/brianespinosa/shippo-packing-slips/issues/26) for CD pipeline implementation status.


### PR DESCRIPTION
## Summary

- Converts all bare issue references in the roadmap to markdown hyperlinks
- Adds issue #35 (Biome + Lefthook + CI) at the top of the roadmap
- Linkifies the #26 reference in the Deployment section