### PR TITLE
feat: CUPS printer integration via lp (#5)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,5 +10,9 @@ SHIPPO_API_TOKEN=your_shippo_live_token_here
 SHIPPO_TEST_API_TOKEN=your_shippo_test_token_here
 
 # Cron Configuration
-# Number of hours to look back for orders
-CRON_TIME_WINDOW_HOURS=24
+# Number of minutes to look back for orders
+CRON_TIME_WINDOW_MINUTES=60
+
+# CUPS Printer Configuration
+# Run `lpstat -p` to list available printer names
+CUPS_PRINTER_NAME=

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -6,7 +6,7 @@ A single Node.js script that runs on a schedule via cron on a Raspberry Pi Zero 
 
 ## What It Does
 
-Each cron run performs two jobs over a configurable time window (default: last 24 hours):
+Each cron run performs two jobs over a configurable time window (default: last 60 minutes):
 
 1. **Packing slips** — Fetch PAID orders from Shippo → generate PDF → print via `lp` → delete temp file
 2. **Shipping labels** — Fetch shipments with Shippo labels → download label PDF → print via `lp` → delete temp file
@@ -24,10 +24,11 @@ Temp files are written to `/tmp` and removed immediately after printing.
 
 ```
 src/
-  index.ts          ← single entry point, orchestrates both jobs
+  index.ts           ← single entry point, orchestrates both jobs
   lib/
-    shippo.ts       ← fetchOrders(), fetchShipments()
     pdf-generator.ts ← generatePackingSlip()
+    printer.ts       ← printPDF() via CUPS lp command
+    shippo.ts        ← fetchOrders(), fetchTransactions()
 ```
 
 Test scripts (`test-shippo.ts`, `test-pdf.ts`) are for local development only and are excluded from the production bundle.
@@ -58,7 +59,10 @@ The script requires a `.env` file on the Pi with:
 
 ```
 SHIPPO_API_TOKEN=shippo_live_...
+CUPS_PRINTER_NAME=Knaon
 ```
+
+See `.env.example` for all available variables.
 
 ## Printer
 

--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ yarn generate                      # fetch orders and generate PDFs
 | `SHIPPO_API_TOKEN` | Shippo production API token |
 | `SHIPPO_TEST_API_TOKEN` | Shippo test token (optional, for test scripts) |
 | `CRON_TIME_WINDOW_MINUTES` | Minutes to look back on each cron run (default: 60) |
+| `CUPS_PRINTER_NAME` | CUPS destination name for the printer (e.g. `Knaon`) |
 
 Values in `.env.local` override `.env`.
 

--- a/src/lib/CLAUDE.md
+++ b/src/lib/CLAUDE.md
@@ -1,0 +1,17 @@
+# src/lib
+
+Library modules used by `src/index.ts`.
+
+## Modules
+
+- `pdf-generator.ts` — `generatePackingSlip(order, outputPath)` — writes a PDFKit packing slip to a temp path
+- `printer.ts` — `printPDF(filePath)` — submits a PDF to CUPS via `lp`; requires `CUPS_PRINTER_NAME` env var
+- `shippo.ts` — `fetchOrders()`, `fetchTransactions()` — Shippo API calls; requires `SHIPPO_API_TOKEN` env var
+
+## Printer notes
+
+- `lp` must be installed on the system (`apt install cups` on the Pi)
+- `lp` submits to the CUPS queue and returns before the document physically prints
+- `CUPS_PRINTER_NAME` is validated at startup in `src/index.ts` (exit 2) and again inside `printPDF`
+- Run `lpstat -p` to list available printer names; `lpstat -o` to see queued jobs
+- To tune print flags for the Knaon 4x6 format, add args to the `lp` array in `printer.ts`

--- a/src/lib/printer.ts
+++ b/src/lib/printer.ts
@@ -1,0 +1,32 @@
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+
+const execFileAsync = promisify(execFile);
+
+export async function printPDF(filePath: string): Promise<void> {
+  const printerName = process.env.CUPS_PRINTER_NAME;
+  if (!printerName) {
+    throw new Error('CUPS_PRINTER_NAME environment variable is required');
+  }
+  try {
+    // lp submits the job to the CUPS queue and returns before printing completes
+    const { stdout, stderr } = await execFileAsync('lp', [
+      '-d',
+      printerName,
+      filePath,
+    ]);
+    const jobId = stdout.trim();
+    if (jobId) {
+      console.log(`  CUPS job: ${jobId}`);
+    }
+    if (stderr.trim()) {
+      console.warn(`  lp warning: ${stderr.trim()}`);
+    }
+  } catch (error) {
+    const exitCode = (error as NodeJS.ErrnoException).code;
+    const message = error instanceof Error ? error.message : String(error);
+    throw new Error(
+      `Failed to print ${filePath} on printer "${printerName}"${exitCode ? ` (${exitCode})` : ''}: ${message}`,
+    );
+  }
+}


### PR DESCRIPTION
## Summary

- Adds `src/lib/printer.ts` with `printPDF(filePath)` using `execFile` (no shell injection risk)
- Validates `CUPS_PRINTER_NAME` at startup — exits 2 if missing, consistent with `SHIPPO_API_TOKEN` guard
- Replaces both `// TODO (#5)` blocks in `runPackingSlipsJob` and `runLabelsJob` with `printPDF()` calls
- Print failures are caught by the existing per-item try/catch, counted as errors, and surfaced in the summary

## Changes

- **`src/lib/printer.ts`** (new) — `printPDF()`: logs CUPS job ID from `lp` stdout, surfaces `lp` stderr as warnings, includes printer name and exit code in failure messages
- **`src/index.ts`** — startup validation for `CUPS_PRINTER_NAME`; both TODO blocks replaced; error messages updated to "Failed to process order/label" (previously implied PDF generation had failed even when the print step failed)
- **`.env.example`** — fix pre-existing bug: `CRON_TIME_WINDOW_HOURS=24` → `CRON_TIME_WINDOW_MINUTES=60`
- **`ARCHITECTURE.md`** — add `printer.ts` to source structure; add `CUPS_PRINTER_NAME` to environment section; fix stale `fetchShipments()` → `fetchTransactions()` reference
- **`src/lib/CLAUDE.md`** (new) — per distributed docs requirement in root CLAUDE.md

## Test plan

- [x] `yarn typecheck` and `yarn check` pass
- [ ] Run with `CUPS_PRINTER_NAME` unset — exits 2 with clear error
- [ ] Run with a bogus printer name — `lp` fails, error is caught and counted in summary, exits 1
- [ ] On the Pi with the real printer — PDFs print and no temp files remain in `/tmp`
- [ ] Confirm `lp` flags needed for Knaon 4x6 format during first hardware test (flags can be added to the args array in `src/lib/printer.ts`)

Closes #5