### PR TITLE
feat: catch unhandled fatal errors and log before exit (closes #6)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -233,4 +233,7 @@ async function run() {
   process.exit(combinedErrors > 0 ? 1 : 0);
 }
 
-void run();
+run().catch((error) => {
+  console.error('Fatal error:', error);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

- Replaces `void run()` with `run().catch()` to handle unexpected top-level errors
- Logs the full error object (including stack trace) before exiting with code 1
- Any error not caught by the inner per-job try/catch blocks is now surfaced clearly

## Test plan

- [x] `yarn generate` with valid config — normal operation unaffected
- [x] `yarn generate` with `SHIPPO_API_TOKEN` unset — still exits 2 (caught before `run()` body)
- [x] Normal runs on Pi continue to produce clean output

Closes #6