### PR TITLE
feat(config): move company details and logo path to environment variables

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,3 +16,15 @@ CRON_TIME_WINDOW_MINUTES=60
 # CUPS Printer Configuration
 # Run `lpstat -p` to list available printer names
 CUPS_PRINTER_NAME=
+
+# Company / packing slip header
+COMPANY_NAME=
+COMPANY_ADDRESS_LINE_1=
+COMPANY_ADDRESS_LINE_2=
+COMPANY_ADDRESS_LINE_3=
+# Absolute or relative path to logo image (optional)
+COMPANY_LOGO_PATH=
+
+# Behavior
+# Set to true to fetch all order statuses instead of only PAID
+INCLUDE_ALL_ORDER_STATUSES=

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -41,14 +41,14 @@ The script runs on a **Raspberry Pi Zero 2 W** (aarch64, 512MB RAM) connected vi
 
 On every merge to `main`, GitHub Actions:
 1. Bundles `src/index.ts` and all dependencies into a single JS file using `@vercel/ncc`
-2. Publishes the bundle as a GitHub Release asset (`bundle.js`)
+2. Publishes the bundle as a GitHub Release asset (`index.js`)
 
 See issue #26 for implementation status.
 
 ### Pi Cron Job
 
 ```
-curl -fsSL https://github.com/brianespinosa/shippo-packing-slips/releases/latest/download/bundle.js | node -
+curl -fsSL https://github.com/brianespinosa/shippo-packing-slips/releases/latest/download/index.js | node -
 ```
 
 No git, yarn, or npm required on the Pi — only `node` and `curl`.

--- a/README.md
+++ b/README.md
@@ -36,6 +36,12 @@ yarn generate                      # fetch orders and generate PDFs
 | `SHIPPO_TEST_API_TOKEN` | Shippo test token (optional, for test scripts) |
 | `CRON_TIME_WINDOW_MINUTES` | Minutes to look back on each cron run (default: 60) |
 | `CUPS_PRINTER_NAME` | CUPS destination name for the printer (e.g. `Knaon`) |
+| `COMPANY_NAME` | Company name rendered in bold on packing slip header (required) |
+| `COMPANY_ADDRESS_LINE_1` | First address line (optional) |
+| `COMPANY_ADDRESS_LINE_2` | Second address line (optional) |
+| `COMPANY_ADDRESS_LINE_3` | Third address line (optional) |
+| `COMPANY_LOGO_PATH` | Absolute or relative path to logo image (optional) |
+| `INCLUDE_ALL_ORDER_STATUSES` | Set to `true` to fetch all order statuses instead of only `PAID` (optional) |
 
 Values in `.env.local` override `.env`.
 
@@ -53,7 +59,7 @@ Values in `.env.local` override `.env`.
 The script is deployed to a Raspberry Pi Zero 2 W. On every merge to `main`, GitHub Actions publishes a bundled release. The Pi cron job pulls and runs it directly:
 
 ```
-curl -fsSL https://github.com/brianespinosa/shippo-packing-slips/releases/latest/download/bundle.js | node -
+curl -fsSL https://github.com/brianespinosa/shippo-packing-slips/releases/latest/download/index.js | node -
 ```
 
 See [issue #26](https://github.com/brianespinosa/shippo-packing-slips/issues/26) for CD pipeline implementation status.

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,7 +17,10 @@ async function runPackingSlipsJob(
 ): Promise<{ success: number; errors: number }> {
   console.log('Fetching orders and generating packing slips...');
 
-  const statusFilter = [OrderStatusEnum.Paid];
+  const statusFilter =
+    process.env.INCLUDE_ALL_ORDER_STATUSES === 'true'
+      ? undefined
+      : [OrderStatusEnum.Paid];
 
   try {
     const orders = await fetchOrders(startDate, endDate, statusFilter);
@@ -187,6 +190,11 @@ async function run() {
   if (!apiToken) {
     console.error('Error: SHIPPO_API_TOKEN not found in environment');
     console.error('Please add your production API token');
+    process.exit(2);
+  }
+
+  if (!process.env.COMPANY_NAME) {
+    console.error('Error: COMPANY_NAME not found in environment');
     process.exit(2);
   }
 

--- a/src/lib/pdf-generator.ts
+++ b/src/lib/pdf-generator.ts
@@ -48,18 +48,6 @@ const TABLE_COLUMN_GAP = 10; // Gap between items and quantity columns
 const TABLE_ROW_PADDING = 6; // Vertical padding top and bottom of each row
 
 /**
- * Business information for "From" address
- * TODO: Move to configuration file
- */
-const BUSINESS_INFO = {
-  city: 'Tacoma',
-  name: 'Bork Tools',
-  state: 'WA',
-  street: '514 S Cushman Ave',
-  zip: '98405',
-};
-
-/**
  * Generate a packing slip PDF for a given order
  * @param order - Order object from Shippo API
  * @param outputPath - Path where the PDF should be saved
@@ -178,44 +166,54 @@ function renderHeader(
   y += SECTION_SPACING / 2;
 
   // Logo and From Address section - centered horizontally
-  const logoPath = path.join(process.cwd(), 'src/assets/bork_logo_bw.png');
+  const companyName = process.env.COMPANY_NAME;
+  if (!companyName) {
+    throw new Error('COMPANY_NAME environment variable is required');
+  }
+  const addressLines = [
+    process.env.COMPANY_ADDRESS_LINE_1,
+    process.env.COMPANY_ADDRESS_LINE_2,
+    process.env.COMPANY_ADDRESS_LINE_3,
+  ].filter(Boolean) as string[];
+
+  const logoPath = process.env.COMPANY_LOGO_PATH;
+  const hasLogo = !!logoPath && fs.existsSync(logoPath);
 
   // Measure actual text widths to calculate proper centering
+  // Company name is bold; address lines are regular weight — measure each with its own font
   doc.font('Inter-Bold');
-  const nameWidth = doc.widthOfString(BUSINESS_INFO.name);
-
+  const nameWidth = doc.widthOfString(companyName);
   doc.font('Inter');
-  const streetWidth = doc.widthOfString(BUSINESS_INFO.street);
-  const cityStateZip = `${BUSINESS_INFO.city}, ${BUSINESS_INFO.state} ${BUSINESS_INFO.zip}`;
-  const cityWidth = doc.widthOfString(cityStateZip);
+  const addressWidths = addressLines.map((l) => doc.widthOfString(l));
+  const maxTextWidth = Math.max(nameWidth, ...addressWidths);
 
-  // Find the widest text line
-  const maxTextWidth = Math.max(nameWidth, streetWidth, cityWidth);
-
-  // Calculate total width and center it
-  const totalWidth = LOGO_WIDTH + LOGO_TEXT_GAP + maxTextWidth;
+  // Calculate total width and center it (only include logo width when present)
+  const totalWidth = hasLogo
+    ? LOGO_WIDTH + LOGO_TEXT_GAP + maxTextWidth
+    : maxTextWidth;
   const startX = (PAGE_WIDTH - totalWidth) / 2;
 
-  if (fs.existsSync(logoPath)) {
-    // Place logo centered
+  if (hasLogo && logoPath) {
     doc.image(logoPath, startX, y, {
       height: LOGO_HEIGHT,
       width: LOGO_WIDTH,
     });
   }
 
-  y += LOGO_TEXT_VERTICAL_OFFSET;
+  if (hasLogo) {
+    y += LOGO_TEXT_VERTICAL_OFFSET;
+  }
 
-  // From Address (to the right of logo)
-  const fromX = startX + LOGO_WIDTH + LOGO_TEXT_GAP;
-  doc.font('Inter-Bold').text(BUSINESS_INFO.name, fromX, y);
+  // From Address (to the right of logo, or centered when no logo)
+  const fromX = hasLogo ? startX + LOGO_WIDTH + LOGO_TEXT_GAP : startX;
+  doc.font('Inter-Bold').text(companyName, fromX, y);
   y += SECTION_LINE_HEIGHT;
 
-  y += SECTION_LINE_HEIGHT;
-  doc
-    .font('Inter')
-    .text(BUSINESS_INFO.street, fromX, y - SECTION_LINE_HEIGHT)
-    .text(cityStateZip, fromX, y);
+  doc.font('Inter');
+  for (const line of addressLines) {
+    doc.text(line, fromX, y);
+    y += SECTION_LINE_HEIGHT;
+  }
 
   // Move past the logo section
   y = Math.max(y + LINE_HEIGHT, MARGIN + LOGO_HEIGHT + SECTION_SPACING);


### PR DESCRIPTION
## Summary

- Removes hardcoded `BUSINESS_INFO` constant (company name, address) and hardcoded logo path from `pdf-generator.ts`
- Adds `COMPANY_NAME` (required), `COMPANY_ADDRESS_LINE_1/2/3` (optional), `COMPANY_LOGO_PATH` (optional) env vars for packing slip header
- Adds `INCLUDE_ALL_ORDER_STATUSES` env var to bypass `PAID`-only order filter
- Logo render and `LOGO_TEXT_VERTICAL_OFFSET` are conditional on logo presence; centering math adjusts accordingly
- Address lines are free-form (supports any country format, 0–3 lines)

## Test plan

- [ ] Set `COMPANY_NAME` + address lines + `COMPANY_LOGO_PATH` in `~/.env` on the Pi
- [ ] Run with a wide `CRON_TIME_WINDOW_MINUTES` and `INCLUDE_ALL_ORDER_STATUSES=true` to pull all statuses
- [ ] Confirm packing slip header renders company name, address, and logo correctly
- [ ] Run without `COMPANY_LOGO_PATH` set — confirm header centers text-only with no gap
- [ ] Confirm startup exits with code 2 if `COMPANY_NAME` is missing