### PR TITLE
docs: document cron job setup and finalize deployment guide

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -51,7 +51,7 @@ Inter font files (`Inter-Regular.ttf`, `Inter-Bold.ttf`) are **not** published i
 The cron job runs at the top of every hour. The command must `cd` to the home directory first so that `dotenv` finds `~/.env`:
 
 ```
-0 * * * * cd /home/bje && node /home/bje/bundle/index.js >> /home/bje/cron.log 2>&1
+0 * * * * cd "$HOME" && node "$HOME/bundle/index.js" >> "$HOME/cron.log" 2>&1
 ```
 
 To install or edit: `crontab -e`. Output is appended to `~/cron.log`.

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Values in `.env.local` override `.env`.
 The script is deployed to a Raspberry Pi Zero 2 W. On every merge to `main`, GitHub Actions publishes a bundled release. The Pi runs `index.js` on a cron schedule from `~/`:
 
 ```
-0 * * * * cd /home/bje && node /home/bje/bundle/index.js >> /home/bje/cron.log 2>&1
+0 * * * * cd "$HOME" && node "$HOME/bundle/index.js" >> "$HOME/cron.log" 2>&1
 ```
 
 To update after a new release:


### PR DESCRIPTION
## Summary

- Documents the actual crontab entry (`0 * * * * cd /home/bje && node /home/bje/bundle/index.js >> ~/cron.log 2>&1`)
- Explains why `cd /home/bje` is required (dotenv resolves `.env` relative to cwd)
- Removes WIP banner and completed roadmap from README
- Removes stale `SHIPPO_TEST_API_TOKEN` and deleted test script entries

## Test plan

- [ ] Verify cron job fires at next hour boundary and appends to `~/cron.log`