### PR TITLE
docs: fix documentation inaccuracies and improve env var table

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,10 +5,6 @@
 # Format: shippo_live_*
 SHIPPO_API_TOKEN=your_shippo_live_token_here
 
-# Test token - used by test scripts to avoid touching production data
-# Format: shippo_test_*
-SHIPPO_TEST_API_TOKEN=your_shippo_test_token_here
-
 # Cron Configuration
 # Number of minutes to look back for orders
 CRON_TIME_WINDOW_MINUTES=60

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -81,9 +81,13 @@ for f in Helvetica.afm Helvetica-Bold.afm Helvetica-BoldOblique.afm Helvetica-Ob
   curl -fsSL "$RELEASE_BASE/$f" -o ~/bundle/"$f"
 done
 
-# Inter fonts (from rsms/inter GitHub releases)
-INTER_BASE=https://github.com/rsms/inter/releases/latest/download
-curl -fsSL "$INTER_BASE/Inter-4.1.zip" -o /tmp/inter.zip
+# Inter fonts (from rsms/inter GitHub releases — fetches latest version dynamically)
+INTER_ZIP_URL=$(curl -fsSL \
+  -H "User-Agent: shippo-packing-slips" \
+  "https://api.github.com/repos/rsms/inter/releases/latest" \
+  | grep -o '"browser_download_url":"[^"]*\.zip"' \
+  | grep -o 'https://[^"]*')
+curl -fsSL "$INTER_ZIP_URL" -o /tmp/inter.zip
 unzip -p /tmp/inter.zip extras/ttf/Inter-Regular.ttf > ~/bundle/Inter-Regular.ttf
 unzip -p /tmp/inter.zip extras/ttf/Inter-Bold.ttf > ~/bundle/Inter-Bold.ttf
 rm /tmp/inter.zip
@@ -106,4 +110,4 @@ See `.env.example` for all available variables.
 - **Hardware**: Knaon thermal printer (USB)
 - **Format**: 4x6 inch labels
 - **Interface**: CUPS (`lp -d <printer-name>`)
-- **Color**: Black and white only (logo converted to grayscale)
+- **Color**: Black and white only (thermal printer hardware limitation; no software conversion)

--- a/README.md
+++ b/README.md
@@ -15,23 +15,23 @@ See `ARCHITECTURE.md` for full system design.
 
 ```bash
 yarn install
-cp .env.local.example .env.local  # add your SHIPPO_API_TOKEN
+cp .env.example .env.local        # add your SHIPPO_API_TOKEN
 yarn generate                      # fetch orders and generate PDFs
 ```
 
 ### Environment Variables
 
-| Variable | Description |
-|---|---|
-| `SHIPPO_API_TOKEN` | Shippo production API token |
-| `CRON_TIME_WINDOW_MINUTES` | Minutes to look back on each cron run (default: 60) |
-| `CUPS_PRINTER_NAME` | CUPS destination name for the printer (e.g. `Knaon`) |
-| `COMPANY_NAME` | Company name rendered in bold on packing slip header (required) |
-| `COMPANY_ADDRESS_LINE_1` | First address line (optional) |
-| `COMPANY_ADDRESS_LINE_2` | Second address line (optional) |
-| `COMPANY_ADDRESS_LINE_3` | Third address line (optional) |
-| `COMPANY_LOGO_PATH` | Absolute or relative path to logo image (optional) |
-| `INCLUDE_ALL_ORDER_STATUSES` | Set to `true` to fetch all order statuses instead of only `PAID` (optional) |
+| Variable | Required | Default | Description |
+|---|---|---|---|
+| `SHIPPO_API_TOKEN` | Yes | | Shippo production API token |
+| `CUPS_PRINTER_NAME` | Yes | | CUPS destination name for the printer (e.g. `Knaon`) |
+| `COMPANY_NAME` | Yes | | Company name rendered in bold on packing slip header |
+| `CRON_TIME_WINDOW_MINUTES` | No | `60` | Minutes to look back on each cron run |
+| `COMPANY_ADDRESS_LINE_1` | No | | First address line |
+| `COMPANY_ADDRESS_LINE_2` | No | | Second address line |
+| `COMPANY_ADDRESS_LINE_3` | No | | Third address line |
+| `COMPANY_LOGO_PATH` | No | | Absolute path to logo image |
+| `INCLUDE_ALL_ORDER_STATUSES` | No | `false` | Set to `true` to fetch all order statuses instead of only `PAID` |
 
 Values in `.env.local` override `.env`.
 
@@ -44,17 +44,4 @@ Values in `.env.local` override `.env`.
 
 ## Deployment
 
-The script is deployed to a Raspberry Pi Zero 2 W. On every merge to `main`, GitHub Actions publishes a bundled release. The Pi runs `index.js` on a cron schedule from `~/`:
-
-```
-0 * * * * cd "$HOME" && node "$HOME/bundle/index.js" >> "$HOME/cron.log" 2>&1
-```
-
-To update after a new release:
-
-```bash
-curl -fsSL https://github.com/brianespinosa/shippo-packing-slips/releases/latest/download/index.js \
-  -o ~/bundle/index.js
-```
-
-See `ARCHITECTURE.md` for full provisioning instructions including one-time asset setup.
+See `ARCHITECTURE.md` for the full deployment model, provisioning instructions, and cron setup.


### PR DESCRIPTION
## Summary

- Fix `cp .env.local.example` → `cp .env.example` (file didn't exist)
- Remove stale `SHIPPO_TEST_API_TOKEN` from `.env.example` (test scripts deleted)
- Fix hardcoded `Inter-4.1.zip` in Pi provisioning script to use GitHub API dynamically
- Fix inaccurate "logo converted to grayscale" — no software conversion occurs; printer is B&W by hardware
- Add Required and Default columns to env var table; sort required vars to top
- Remove redundant Deployment section from README (covered fully in ARCHITECTURE.md)

## Test plan

- [ ] Verify `cp .env.example .env.local` works for local setup
- [ ] Verify Inter font provisioning script fetches latest release dynamically