### PR TITLE
ci: composite setup action, --immutable fix, concurrency

### DIFF
--- a/.github/CLAUDE.md
+++ b/.github/CLAUDE.md
@@ -22,9 +22,9 @@
 
 ### `.github/actions/setup`
 
-Shared setup sequence used by all three workflows. Encapsulates: checkout, Node.js setup via `.nvmrc`, corepack enable, and `yarn install --immutable`.
+Shared setup sequence used by all three workflows. Encapsulates: Node.js setup via `.nvmrc`, corepack enable, and `yarn install --immutable`.
 
-Reference with `uses: ./.github/actions/setup` (no `with` inputs required).
+**Important**: Local composite actions cannot self-checkout — the runner workspace must already contain the repo when GitHub resolves the action definition. Each calling workflow must run `actions/checkout` as its first step before `uses: ./.github/actions/setup`.
 
 ## Common Tasks
 

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -1,11 +1,9 @@
-name: Checkout, setup Node, and install dependencies
-description: Checks out the repo, sets up Node.js via .nvmrc, enables corepack, and installs dependencies.
+name: Setup Node and install dependencies
+description: Sets up Node.js via .nvmrc, enables corepack, and installs dependencies. Requires checkout to have already run.
 
 runs:
   using: composite
   steps:
-    - name: Checkout
-      uses: actions/checkout@v6
     - name: Setup Node
       uses: actions/setup-node@v6
       with:

--- a/.github/workflows/biome.yml
+++ b/.github/workflows/biome.yml
@@ -12,6 +12,8 @@ jobs:
   check:
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout
+        uses: actions/checkout@v6
       - name: Setup
         uses: ./.github/actions/setup
       - name: Run Biome

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,6 +19,8 @@ jobs:
     permissions:
       contents: write
     steps:
+      - name: Checkout
+        uses: actions/checkout@v6
       - name: Setup
         uses: ./.github/actions/setup
       - name: Build bundle

--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -12,6 +12,8 @@ jobs:
   typecheck:
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout
+        uses: actions/checkout@v6
       - name: Setup
         uses: ./.github/actions/setup
       - name: Run TypeCheck


### PR DESCRIPTION
## Summary

- Extracts the shared 4-step setup sequence (checkout, Node, corepack, yarn install) into `.github/actions/setup` composite action
- Updates `biome.yml`, `typecheck.yml`, and `release.yml` to use `uses: ./.github/actions/setup`
- Fixes `--frozen-lockfile` deprecation warning — composite action uses the correct Yarn 4 flag `--immutable`
- Adds `concurrency` to all three workflows with `cancel-in-progress: true`; PR workflows key on `pull_request.number`, `release.yml` keys on `github.ref`

## Test plan

- [ ] Verify all three workflows trigger and pass on this PR (biome, typecheck)
- [ ] Confirm no `--frozen-lockfile` deprecation warnings in CI logs
- [ ] Confirm `release.yml` publishes correctly when triggered by a source file change
- [ ] Confirm concurrent runs on the same PR are cancelled correctly

## References

Closes #47