### PR TITLE
chore: add GitHub remote MCP configuration

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -30,3 +30,9 @@ See [settings.json](settings.json) for the current list of approved commands.
 - **settings.local.json** - Machine-specific settings (ignored by global gitignore, never committed)
 
 Local settings override shared settings, allowing individual users to customize their experience while maintaining common defaults.
+
+## MCP Configuration
+
+- `.mcp.json` (repo root) — project-scoped MCP servers, committed to the repository and shared with all collaborators including cloud environments
+  - Currently configures the GitHub remote MCP via `https://api.githubcopilot.com/mcp`
+  - Requires a `GITHUB_PAT` environment variable with the following scopes: `repo`, `read:org`, `read:packages`, `notifications`, `security_events`, `gist`, `project`

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,11 @@
+{
+  "mcpServers": {
+    "github": {
+      "type": "http",
+      "url": "https://api.githubcopilot.com/mcp",
+      "headers": {
+        "Authorization": "Bearer ${GITHUB_PAT}"
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- Adds `.mcp.json` with the GitHub remote MCP server configured for use in cloud environments
- Uses the HTTP transport type pointing to `https://api.githubcopilot.com/mcp`
- Authenticates via a `GITHUB_PAT` environment variable

## Test plan

- [ ] Verify `GITHUB_PAT` env var is set with required scopes (`repo`, `read:org`, `read:packages`, `notifications`, `security_events`, `gist`, `project`) in the target cloud environment
- [ ] Confirm the MCP server connects successfully in a cloud Claude Code session