### PR TITLE
chore: add probot/settings configuration

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -1,0 +1,7 @@
+_extends: brianespinosa/settings:base.yml
+
+repository:
+  name: shippo-packing-slips
+  description: Raspberry Pi Zero scripts to generate custom packing slips and print them and any new shipping labels at regular intervals using Shippo API
+  topics: raspberry-pi-zero-2-w, shippo
+  private: false


### PR DESCRIPTION
## Summary

- Adds `.github/settings.yml` extending `brianespinosa/settings:base.yml`
- Populates `repository:` block with current GitHub metadata

## Why

Enrolls this repo in centralized settings management via the probot/settings app, ensuring branch protection, merge strategy, and labels stay in sync with the shared configuration.