### PR TITLE
chore: add GitHub MCP server settings

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,4 +1,6 @@
 {
+  "enableAllProjectMcpServers": true,
+  "enabledMcpjsonServers": ["github"],
   "permissions": {
     "allow": [
       "Bash(gh issue create:*)",


### PR DESCRIPTION
Add `enableAllProjectMcpServers` and `enabledMcpjsonServers` to `.claude/settings.json` to enable the GitHub MCP server.