### PR TITLE
ci: add dependabot auto-merge workflow

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,16 @@
+name: Dependabot Auto-merge
+
+on: pull_request_target
+
+jobs:
+  auto-merge:
+    runs-on: ubuntu-latest
+    if: github.actor == 'dependabot[bot]'
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Adds the Dependabot auto-merge workflow from `brianespinosa/career`, copied exactly.

## Changes

- `.github/workflows/dependabot-auto-merge.yml` — triggers on `pull_request_target` from `dependabot[bot]` and squash-merges via `gh pr merge --auto`

## References

- Source: `brianespinosa/career` @ `.github/workflows/dependabot-auto-merge.yml`