### PR TITLE
docs: remove duplicate ARCHITECTURE.md reference and linkify remaining

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,9 +5,6 @@
 
 Raspberry Pi scripts to print packing slips, shipping labels, and schedule USPS pickups at regular intervals using the Shippo API
 
-See `ARCHITECTURE.md` for full system design.
-
-
 ## Requirements
 
 - Node.js 24
@@ -49,4 +46,4 @@ Values in `.env.local` override `.env`.
 
 ## Deployment
 
-See `ARCHITECTURE.md` for the full deployment model, provisioning instructions, and cron setup.
+See [ARCHITECTURE.md](ARCHITECTURE.md) for the full deployment model, provisioning instructions, and cron setup.


### PR DESCRIPTION
## Summary

- Removes redundant `See ARCHITECTURE.md for full system design` line from the top of the README (duplicate of the reference in the Deployment section)
- Converts the remaining `ARCHITECTURE.md` reference in the Deployment section to a proper markdown link