### PR TITLE
docs: add backticks to ARCHITECTURE.md link

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,4 +46,4 @@ Values in `.env.local` override `.env`.
 
 ## Deployment
 
-See [ARCHITECTURE.md](ARCHITECTURE.md) for the full deployment model, provisioning instructions, and cron setup.
+See [`ARCHITECTURE.md`](ARCHITECTURE.md) for the full deployment model, provisioning instructions, and cron setup.


### PR DESCRIPTION
## Summary

- Restores backtick formatting on the `ARCHITECTURE.md` link in the Deployment section so it renders as both a link and inline code