### PR TITLE
feat: include confirmed pickup window in summary output

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -275,6 +275,8 @@ async function runLabelsJob(
 async function runPickupJob(transactionIds: string[]): Promise<{
   scheduled: boolean;
   confirmationCode?: string;
+  confirmedStartTime?: string;
+  confirmedEndTime?: string;
   error?: string;
 }> {
   if (transactionIds.length === 0) {
@@ -331,7 +333,12 @@ async function runPickupJob(transactionIds: string[]): Promise<{
       },
     });
 
-    return { scheduled: true, confirmationCode: pickup.confirmationCode };
+    return {
+      scheduled: true,
+      confirmationCode: pickup.confirmationCode,
+      confirmedStartTime: pickup.confirmedStartTime,
+      confirmedEndTime: pickup.confirmedEndTime,
+    };
   } catch (error) {
     const message = error instanceof Error ? error.message : 'Unknown error';
     console.error(`✗ Pickup scheduling failed: ${message}`);
@@ -400,9 +407,14 @@ async function run() {
   if (labelResults.printedTransactionIds.length === 0) {
     pickupSummary = 'not scheduled (no new labels this run)';
   } else if (pickupResult.scheduled) {
-    pickupSummary = pickupResult.confirmationCode
-      ? `scheduled (confirmation: ${pickupResult.confirmationCode})`
-      : 'scheduled (no confirmation code returned)';
+    const confirmation = pickupResult.confirmationCode
+      ? ` (confirmation: ${pickupResult.confirmationCode})`
+      : '';
+    const window =
+      pickupResult.confirmedStartTime && pickupResult.confirmedEndTime
+        ? ` — ${pickupResult.confirmedStartTime} to ${pickupResult.confirmedEndTime}`
+        : '';
+    pickupSummary = `scheduled${confirmation}${window}`;
   } else {
     pickupSummary = `FAILED — ${pickupResult.error}`;
   }


### PR DESCRIPTION
## Summary

- Extends `runPickupJob` return type to include `confirmedStartTime` and `confirmedEndTime` from the Shippo pickup response
- Summary line now shows the carrier-confirmed pickup window alongside the confirmation code, e.g.:
  ```
  Pickup: scheduled (confirmation: EMC717902446) — 2026-04-08T10:00:00Z to 2026-04-08T14:00:00Z
  ```

The confirmed window is narrower than the requested window (tomorrow 08:00 UTC – D+4 18:00 UTC) and represents the actual time USPS commits to for the pickup.