### PR TITLE
ci: add workflow_dispatch trigger to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,7 @@ on:
       - 'package.json'
       - 'yarn.lock'
       - 'tsconfig.json'
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
## Summary

- Adds `workflow_dispatch` trigger to `release.yml` so the release can be run manually via `gh workflow run release.yml` or from the GitHub Actions UI