### PR TITLE
test: integration tests against Shippo test API (Phase 2)

### DIFF
--- a/.github/CLAUDE.md
+++ b/.github/CLAUDE.md
@@ -12,6 +12,8 @@
 
 **unit-tests.yml** — Runs `yarn test` (Vitest) on PRs targeting `main`. Enforces that all unit tests pass and that `src/lib/**` maintains 100% coverage.
 
+**integration-tests.yml** — Runs `yarn test:integration` (Vitest) on PRs targeting `main`, on a weekly Monday cron, and on manual dispatch. Calls the real Shippo test-mode API via `SHIPPO_TEST_API_TOKEN` secret. Uses `github.ref` in the concurrency group (rather than `pull_request.number`) because the workflow has three triggers and `pull_request.number` is empty for schedule/dispatch runs.
+
 ## Composite Actions
 
 ### `.github/actions/setup`

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -1,0 +1,25 @@
+name: Integration Tests
+
+on:
+  pull_request:
+    branches: [main]
+  schedule:
+    - cron: '0 9 * * 1'
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  integration-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+      - name: Setup
+        uses: ./.github/actions/setup
+      - name: Run integration tests
+        env:
+          SHIPPO_API_TOKEN: ${{ secrets.SHIPPO_TEST_API_TOKEN }}
+        run: yarn test:integration

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![Biome](https://github.com/brianespinosa/shippo-packing-slips/actions/workflows/biome.yml/badge.svg)](https://github.com/brianespinosa/shippo-packing-slips/actions/workflows/biome.yml)
 [![Typecheck](https://github.com/brianespinosa/shippo-packing-slips/actions/workflows/typecheck.yml/badge.svg)](https://github.com/brianespinosa/shippo-packing-slips/actions/workflows/typecheck.yml)
 [![Unit Tests](https://github.com/brianespinosa/shippo-packing-slips/actions/workflows/unit-tests.yml/badge.svg)](https://github.com/brianespinosa/shippo-packing-slips/actions/workflows/unit-tests.yml)
+[![Integration Tests](https://github.com/brianespinosa/shippo-packing-slips/actions/workflows/integration-tests.yml/badge.svg)](https://github.com/brianespinosa/shippo-packing-slips/actions/workflows/integration-tests.yml)
 
 Raspberry Pi scripts to print packing slips, shipping labels, and schedule USPS pickups at regular intervals using the Shippo API
 

--- a/src/integration/CLAUDE.md
+++ b/src/integration/CLAUDE.md
@@ -1,0 +1,28 @@
+# src/integration
+
+Integration tests that call the real Shippo test-mode API. These are distinct from unit tests in `src/lib/` and `src/services/` — they verify the live API contract, not internal logic.
+
+## Running
+
+```bash
+SHIPPO_API_TOKEN=shippo_test_... yarn test:integration
+```
+
+Requires a Shippo **test-mode** token (starts with `shippo_test_`). The production `SHIPPO_API_TOKEN` must **not** be used here.
+
+## Test Lifecycle
+
+Each test run creates a fresh Shippo transaction in `beforeAll` and voids it via a refund in `afterAll`. This ensures tests are self-contained and do not depend on pre-existing state in the test account.
+
+See `helpers.ts` for `setupTestTransaction` / `teardownTestTransaction`. These helpers are designed to be reused across future integration test files.
+
+## Key Files
+
+- `helpers.ts` — shared setup/teardown; creates a test shipment → rate → transaction, voids on cleanup
+- `shippo-api.test.ts` — tests for `fetchOrders`, `fetchTransactions`, `fetchPickupDetails`
+
+## Adding New Tests
+
+- Import `setupTestTransaction` / `teardownTestTransaction` from `./helpers`
+- Use a `beforeAll` with a 30s timeout to accommodate sequential Shippo API calls
+- Assert exact values against the known test fixture address (`Test Sender`, `123 Main St`, etc.) rather than just type checks

--- a/src/integration/helpers.ts
+++ b/src/integration/helpers.ts
@@ -151,9 +151,6 @@ export async function teardownTestTransaction(
 
   try {
     await client.refunds.create({ transaction: transactionId });
-    console.log(
-      `[teardownTestTransaction] Voided transaction ${transactionId}.`,
-    );
   } catch (error) {
     // Best-effort cleanup — do not fail the test suite, but warn so the failure
     // is visible and the transaction can be manually voided if needed.

--- a/src/integration/helpers.ts
+++ b/src/integration/helpers.ts
@@ -1,0 +1,88 @@
+import type { Shippo } from 'shippo';
+import { DistanceUnitEnum, WeightUnitEnum } from 'shippo/models/components';
+
+import { createShippoClient } from '../services/shippo';
+
+export async function setupTestTransaction(): Promise<{
+  client: Shippo;
+  transactionId: string;
+}> {
+  const client = createShippoClient();
+
+  const shipment = await client.shipments
+    .create({
+      addressFrom: {
+        name: 'Test Sender',
+        street1: '123 Main St',
+        city: 'San Francisco',
+        state: 'CA',
+        zip: '94103',
+        country: 'US',
+      },
+      addressTo: {
+        name: 'Test Recipient',
+        street1: '456 Oak Ave',
+        city: 'New York',
+        state: 'NY',
+        zip: '10001',
+        country: 'US',
+      },
+      parcels: [
+        {
+          length: '10',
+          width: '10',
+          height: '10',
+          distanceUnit: DistanceUnitEnum.In,
+          weight: '2',
+          massUnit: WeightUnitEnum.Lb,
+        },
+      ],
+      async: false,
+    })
+    .catch((err) => {
+      throw new Error(
+        `setupTestTransaction: shipments.create failed — ${err instanceof Error ? err.message : String(err)}`,
+      );
+    });
+
+  if (!shipment.rates?.length) {
+    throw new Error('No rates returned for test shipment');
+  }
+
+  const rateId = shipment.rates[0].objectId;
+
+  if (!rateId) {
+    throw new Error('First rate has no objectId');
+  }
+
+  const transaction = await client.transactions
+    .create({ rate: rateId, async: false })
+    .catch((err) => {
+      throw new Error(
+        `setupTestTransaction: transactions.create failed — ${err instanceof Error ? err.message : String(err)}`,
+      );
+    });
+
+  if (!transaction.objectId) {
+    throw new Error('Transaction was created but has no objectId');
+  }
+
+  return { client, transactionId: transaction.objectId };
+}
+
+export async function teardownTestTransaction(
+  client: Shippo,
+  transactionId: string,
+): Promise<void> {
+  try {
+    await client.refunds.create({ transaction: transactionId });
+  } catch (error) {
+    // Best-effort cleanup — do not fail the test suite, but warn so the failure
+    // is visible and the transaction can be manually voided if needed.
+    console.warn(
+      `[teardownTestTransaction] Failed to void transaction ${transactionId} — ` +
+        `manual cleanup may be required in your Shippo test-mode account. ` +
+        `Reason: ${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
+}

--- a/src/integration/helpers.ts
+++ b/src/integration/helpers.ts
@@ -111,8 +111,13 @@ async function waitForTransactionSuccess(
     }
 
     if (tx.status === TransactionStatusEnum.Error) {
+      const messages = (tx.messages ?? [])
+        .map((m) => m.text)
+        .filter(Boolean)
+        .join('; ');
       throw new Error(
-        `Transaction ${transactionId} reached ERROR state — label generation failed in Shippo test mode.`,
+        `Transaction ${transactionId} reached ERROR state.` +
+          (messages ? ` Shippo messages: ${messages}` : ''),
       );
     }
 

--- a/src/integration/helpers.ts
+++ b/src/integration/helpers.ts
@@ -45,10 +45,10 @@ export async function setupTestTransaction(): Promise<{
       },
       addressTo: {
         name: 'Test Recipient',
-        street1: '456 Oak Ave',
+        street1: '215 Water St',
         city: 'New York',
         state: 'NY',
-        zip: '10001',
+        zip: '10038',
         country: 'US',
       },
       parcels: [

--- a/src/integration/helpers.ts
+++ b/src/integration/helpers.ts
@@ -43,6 +43,7 @@ export async function setupTestTransaction(): Promise<{
         zip: '94103',
         country: 'US',
         email: 'test@example.com',
+        phone: '4155550100',
       },
       addressTo: {
         name: 'Test Recipient',

--- a/src/integration/helpers.ts
+++ b/src/integration/helpers.ts
@@ -151,6 +151,9 @@ export async function teardownTestTransaction(
 
   try {
     await client.refunds.create({ transaction: transactionId });
+    console.log(
+      `[teardownTestTransaction] Voided transaction ${transactionId}.`,
+    );
   } catch (error) {
     // Best-effort cleanup — do not fail the test suite, but warn so the failure
     // is visible and the transaction can be manually voided if needed.

--- a/src/integration/helpers.ts
+++ b/src/integration/helpers.ts
@@ -90,7 +90,38 @@ export async function setupTestTransaction(): Promise<{
     throw new Error('Transaction was created but has no objectId');
   }
 
+  await waitForTransactionSuccess(client, transaction.objectId);
+
   return { client, transactionId: transaction.objectId };
+}
+
+async function waitForTransactionSuccess(
+  client: Shippo,
+  transactionId: string,
+  timeoutMs = 20_000,
+  intervalMs = 1_000,
+): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+
+  while (Date.now() < deadline) {
+    const tx = await client.transactions.get(transactionId);
+
+    if (tx.status === TransactionStatusEnum.Success) {
+      return;
+    }
+
+    if (tx.status === TransactionStatusEnum.Error) {
+      throw new Error(
+        `Transaction ${transactionId} reached ERROR state — label generation failed in Shippo test mode.`,
+      );
+    }
+
+    await new Promise((resolve) => setTimeout(resolve, intervalMs));
+  }
+
+  throw new Error(
+    `Transaction ${transactionId} did not reach SUCCESS within ${timeoutMs}ms.`,
+  );
 }
 
 export async function teardownTestTransaction(

--- a/src/integration/helpers.ts
+++ b/src/integration/helpers.ts
@@ -1,5 +1,9 @@
 import type { Shippo } from 'shippo';
-import { DistanceUnitEnum, WeightUnitEnum } from 'shippo/models/components';
+import {
+  DistanceUnitEnum,
+  TransactionStatusEnum,
+  WeightUnitEnum,
+} from 'shippo/models/components';
 
 import { createShippoClient } from '../services/shippo';
 
@@ -67,6 +71,13 @@ export async function setupTestTransaction(): Promise<{
     throw new Error('Transaction was created but has no objectId');
   }
 
+  if (transaction.status !== TransactionStatusEnum.Success) {
+    throw new Error(
+      `Transaction ${transaction.objectId} is in ${transaction.status} state — ` +
+        `expected SUCCESS. Label generation failed in Shippo test mode.`,
+    );
+  }
+
   return { client, transactionId: transaction.objectId };
 }
 
@@ -74,6 +85,20 @@ export async function teardownTestTransaction(
   client: Shippo,
   transactionId: string,
 ): Promise<void> {
+  // Only SUCCESS transactions can be refunded — ERROR/VOIDED/etc. have no label to void.
+  let status: string | undefined;
+  try {
+    const tx = await client.transactions.get(transactionId);
+    status = tx.status;
+  } catch {
+    // If we can't fetch the transaction, skip cleanup silently.
+    return;
+  }
+
+  if (status !== TransactionStatusEnum.Success) {
+    return;
+  }
+
   try {
     await client.refunds.create({ transaction: transactionId });
   } catch (error) {

--- a/src/integration/helpers.ts
+++ b/src/integration/helpers.ts
@@ -1,5 +1,6 @@
 import type { Shippo } from 'shippo';
 import {
+  CarriersEnum,
   DistanceUnitEnum,
   TransactionStatusEnum,
   WeightUnitEnum,
@@ -13,8 +14,27 @@ export async function setupTestTransaction(): Promise<{
 }> {
   const client = createShippoClient();
 
+  // Filter to USPS carrier accounts — other carriers may fail label generation
+  // in test mode. This follows the pattern in the Shippo SDK's own test suite.
+  const carrierAccountsResponse = await client.carrierAccounts
+    .list({ carrier: CarriersEnum.Usps })
+    .catch((err) => {
+      throw new Error(
+        `setupTestTransaction: carrierAccounts.list failed — ${err instanceof Error ? err.message : String(err)}`,
+      );
+    });
+
+  const carrierAccountIds = (carrierAccountsResponse.results ?? [])
+    .map((ca) => ca.objectId)
+    .filter((id): id is string => id !== undefined);
+
+  if (!carrierAccountIds.length) {
+    throw new Error('No USPS carrier accounts found in test account');
+  }
+
   const shipment = await client.shipments
     .create({
+      carrierAccounts: carrierAccountIds,
       addressFrom: {
         name: 'Test Sender',
         street1: '123 Main St',
@@ -33,15 +53,14 @@ export async function setupTestTransaction(): Promise<{
       },
       parcels: [
         {
-          length: '10',
-          width: '10',
-          height: '10',
+          length: '5',
+          width: '5',
+          height: '5',
           distanceUnit: DistanceUnitEnum.In,
           weight: '2',
           massUnit: WeightUnitEnum.Lb,
         },
       ],
-      async: false,
     })
     .catch((err) => {
       throw new Error(
@@ -60,7 +79,7 @@ export async function setupTestTransaction(): Promise<{
   }
 
   const transaction = await client.transactions
-    .create({ rate: rateId, async: false })
+    .create({ rate: rateId })
     .catch((err) => {
       throw new Error(
         `setupTestTransaction: transactions.create failed — ${err instanceof Error ? err.message : String(err)}`,
@@ -69,13 +88,6 @@ export async function setupTestTransaction(): Promise<{
 
   if (!transaction.objectId) {
     throw new Error('Transaction was created but has no objectId');
-  }
-
-  if (transaction.status !== TransactionStatusEnum.Success) {
-    throw new Error(
-      `Transaction ${transaction.objectId} is in ${transaction.status} state — ` +
-        `expected SUCCESS. Label generation failed in Shippo test mode.`,
-    );
   }
 
   return { client, transactionId: transaction.objectId };

--- a/src/integration/helpers.ts
+++ b/src/integration/helpers.ts
@@ -42,6 +42,7 @@ export async function setupTestTransaction(): Promise<{
         state: 'CA',
         zip: '94103',
         country: 'US',
+        email: 'test@example.com',
       },
       addressTo: {
         name: 'Test Recipient',

--- a/src/integration/shippo-api.test.ts
+++ b/src/integration/shippo-api.test.ts
@@ -1,0 +1,122 @@
+import { TransactionStatusEnum } from 'shippo/models/components';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+import {
+  fetchOrders,
+  fetchPickupDetails,
+  fetchTransactions,
+} from '../services/shippo';
+import { setupTestTransaction, teardownTestTransaction } from './helpers';
+
+let testSetup: Awaited<ReturnType<typeof setupTestTransaction>>;
+
+beforeAll(async () => {
+  if (!process.env.SHIPPO_API_TOKEN) {
+    throw new Error(
+      'SHIPPO_API_TOKEN is required for integration tests. ' +
+        'Set a Shippo test-mode token (shippo_test_...) in the environment.',
+    );
+  }
+  testSetup = await setupTestTransaction();
+}, 30_000);
+
+afterAll(async () => {
+  if (testSetup) {
+    await teardownTestTransaction(testSetup.client, testSetup.transactionId);
+  } else {
+    console.warn(
+      '[afterAll] testSetup is undefined — teardown skipped. ' +
+        'If a transaction was created before beforeAll failed, it may need manual cleanup.',
+    );
+  }
+});
+
+describe('fetchTransactions', () => {
+  let recentResults: Awaited<ReturnType<typeof fetchTransactions>>;
+  let windowStart: Date;
+  let windowEnd: Date;
+
+  beforeAll(async () => {
+    windowEnd = new Date();
+    windowStart = new Date(windowEnd.getTime() - 7 * 24 * 60 * 60 * 1000);
+    recentResults = await fetchTransactions(windowStart, windowEnd);
+  });
+
+  it('returns an array for a recent time window', () => {
+    expect(Array.isArray(recentResults)).toBe(true);
+  });
+
+  it('all returned transactions have labelUrl set', () => {
+    for (const tx of recentResults) {
+      expect(tx.labelUrl).toBeTruthy();
+    }
+  });
+
+  it('all returned transactions have objectCreated defined', () => {
+    for (const tx of recentResults) {
+      expect(tx.objectCreated).toBeDefined();
+    }
+  });
+
+  it('all returned transactions fall within the requested date range', () => {
+    for (const tx of recentResults) {
+      expect(tx.objectCreated?.getTime()).toBeGreaterThanOrEqual(
+        windowStart.getTime(),
+      );
+      expect(tx.objectCreated?.getTime()).toBeLessThanOrEqual(
+        windowEnd.getTime(),
+      );
+    }
+  });
+
+  it('all returned transactions have SUCCESS status', () => {
+    for (const tx of recentResults) {
+      expect(tx.status).toBe(TransactionStatusEnum.Success);
+    }
+  });
+
+  it('returns an empty array for a future time window', async () => {
+    const futureStart = new Date('2099-01-01T00:00:00.000Z');
+    const futureEnd = new Date('2099-01-02T00:00:00.000Z');
+    const results = await fetchTransactions(futureStart, futureEnd);
+    expect(results).toEqual([]);
+  });
+});
+
+describe('fetchOrders', () => {
+  it('returns an array for a recent time window', async () => {
+    const end = new Date();
+    const start = new Date(end.getTime() - 7 * 24 * 60 * 60 * 1000);
+    const results = await fetchOrders(start, end);
+    expect(Array.isArray(results)).toBe(true);
+  });
+
+  it('returns an empty array for a future time window', async () => {
+    const futureStart = new Date('2099-01-01T00:00:00.000Z');
+    const futureEnd = new Date('2099-01-02T00:00:00.000Z');
+    const results = await fetchOrders(futureStart, futureEnd);
+    expect(results).toEqual([]);
+  });
+});
+
+describe('fetchPickupDetails', () => {
+  it('resolves carrierAccount and address from test transaction', async () => {
+    if (!testSetup) {
+      throw new Error('testSetup not initialized — beforeAll likely failed');
+    }
+    const details = await fetchPickupDetails(testSetup.transactionId);
+    expect(typeof details.carrierAccount).toBe('string');
+    expect(details.carrierAccount.length).toBeGreaterThan(0);
+    expect(details.address.name).toBe('Test Sender');
+    expect(details.address.street1).toBe('123 Main St');
+    expect(details.address.city).toBe('San Francisco');
+    expect(details.address.state).toBe('CA');
+    expect(details.address.zip).toBe('94103');
+  });
+
+  it('throws a descriptive error for an unknown transaction ID', async () => {
+    await expect(
+      fetchPickupDetails('nonexistent-transaction-id-00000'),
+    ).rejects.toThrow('Failed to fetch pickup details');
+  });
+});

--- a/src/integration/shippo-api.test.ts
+++ b/src/integration/shippo-api.test.ts
@@ -18,7 +18,7 @@ beforeAll(async () => {
     );
   }
   testSetup = await setupTestTransaction();
-}, 30_000);
+}, 60_000);
 
 afterAll(async () => {
   if (testSetup) {

--- a/src/services/shippo.ts
+++ b/src/services/shippo.ts
@@ -121,9 +121,6 @@ export async function fetchTransactions(
       for (const tx of pageResults) {
         const result = filterTransaction(tx, startDate, endDate);
         if (result === 'stop') {
-          console.log(
-            `  Stopping pagination: reached transaction before window (${tx.objectCreated?.toISOString()})`,
-          );
           hasMore = false;
           break;
         }

--- a/vitest.integration.config.ts
+++ b/vitest.integration.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    globals: false,
+    include: ['src/integration/**/*.test.ts'],
+    testTimeout: 30000,
+  },
+});

--- a/vitest.integration.config.ts
+++ b/vitest.integration.config.ts
@@ -6,5 +6,6 @@ export default defineConfig({
     globals: false,
     include: ['src/integration/**/*.test.ts'],
     testTimeout: 30000,
+    reporter: 'verbose',
   },
 });


### PR DESCRIPTION
## Summary

- Adds `vitest.integration.config.ts` (standalone config, 30s timeout, targets `src/integration/**`)
- Adds `src/integration/helpers.ts` with `setupTestTransaction` / `teardownTestTransaction` — creates a fresh Shippo transaction per run and voids it after, avoiding any dependency on pre-existing test-account state
- Adds `src/integration/shippo-api.test.ts` covering `fetchOrders`, `fetchTransactions`, and `fetchPickupDetails` with exact address assertions, empty-window checks, and `SUCCESS` status verification
- Adds `.github/workflows/integration-tests.yml` triggering on PR, weekly Monday cron, and manual dispatch via `SHIPPO_TEST_API_TOKEN` secret
- Adds Integration Tests badge to `README.md`
- Adds `src/integration/CLAUDE.md` and updates `.github/CLAUDE.md`

## Test plan

- [ ] `yarn test` passes (unit tests unaffected)
- [ ] `SHIPPO_API_TOKEN=shippo_test_... yarn test:integration` passes locally
- [ ] Integration Tests workflow passes in GitHub Actions on this PR
- [ ] `SHIPPO_TEST_API_TOKEN` secret is confirmed present in repository Actions secrets

Closes #77