### PR TITLE
docs: remove attribution guidance in favor of settings config

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -85,13 +85,9 @@ Common types: `feat`, `fix`, `docs`, `refactor`, `test`, `chore`, `ci`
 
 - Keep messages brief and easy to parse - avoid lengthy descriptions
 - Focus on specific, scannable details that help humans quickly identify what a commit contains
-- **NEVER** add "🤖 Generated with Claude Code" or similar footers to commit messages
-- **NEVER** add "Co-Authored-By: Claude" or any co-author footers to commits
 
 **Pull request requirements:**
 
-- **NEVER** add "Co-Authored-By: Claude" or any co-author attribution to PR descriptions
-- **NEVER** add "🤖 Generated with Claude Code" or similar attribution to PRs
 - Keep PR descriptions focused on technical changes, testing, and references
 
 ### File Operations and Repository Root


### PR DESCRIPTION
Removes the `CLAUDE.md` guidance forbidding `Co-Authored-By: Claude` and "Generated with Claude Code" footers. That behavior is now controlled by Claude Code configuration rather than project memory:

```json
"attribution": {
  "commit": "",
  "pr": ""
}
```

Empty strings suppress the attribution text at the harness level, so the prose instruction is redundant. Set in user-level `~/.claude/settings.json`.

The non-attribution bullet in the same section is retained: `Keep PR descriptions focused on technical changes, testing, and references`.

## Testing

Documentation only, no code paths touched. Pre-commit hooks ran and passed.